### PR TITLE
Update EventSummarySection to refresh time

### DIFF
--- a/src/app/components/event/EventSummarySection.tsx
+++ b/src/app/components/event/EventSummarySection.tsx
@@ -23,7 +23,11 @@ export default function EventSummarySection() {
   const [now, setNow] = useState(new Date());
 
   useEffect(() => {
-    setNow(new Date());
+    const interval = setInterval(() => {
+      setNow(new Date());
+    }, 60_000);
+
+    return () => clearInterval(interval);
   }, []);
 
   const currentEvents = useMemo(() => {


### PR DESCRIPTION
## Summary
- refresh `now` in `EventSummarySection` every minute using `setInterval`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fbf65d2348322b26c735cf099c4bb