### PR TITLE
Add vitest and tests for operator utilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "vitest"
   },
   "dependencies": {
     "@radix-ui/react-collapsible": "^1.1.11",
@@ -39,6 +40,7 @@
     "eslint-config-next": "15.3.2",
     "tailwindcss": "^4",
     "tw-animate-css": "^1.3.0",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^1.4.0"
   }
 }

--- a/src/app/components/operator/OperatorList.tsx
+++ b/src/app/components/operator/OperatorList.tsx
@@ -6,7 +6,7 @@ import operatorData from "@/data/operators.json";
 import { cn } from "@/lib/utils";
 import { useTranslations, useLocale } from "next-intl";
 import type { Operator } from "@/lib/operator-utils";
-import { getCombinations, getMatchingTagGroups } from "@/lib/operator-utils";
+import { getMatchingTagGroups } from "@/lib/operator-utils";
 
 type Props = {
   title: string;

--- a/src/app/components/operator/OperatorList.tsx
+++ b/src/app/components/operator/OperatorList.tsx
@@ -5,53 +5,14 @@ import OperatorItem from "./OperatorItem";
 import operatorData from "@/data/operators.json";
 import { cn } from "@/lib/utils";
 import { useTranslations, useLocale } from "next-intl";
-
-type Operator = {
-  name: string;
-  tags: string[];
-  image: string;
-  stars: number;
-};
+import type { Operator } from "@/lib/operator-utils";
+import { getCombinations, getMatchingTagGroups } from "@/lib/operator-utils";
 
 type Props = {
   title: string;
   selectedTags: string[];
 };
 
-function getCombinations(tags: string[]): string[][] {
-  const results: string[][] = [];
-  const backtrack = (start: number, path: string[]) => {
-    if (path.length > 0) results.push([...path]);
-    for (let i = start; i < tags.length; i++) {
-      path.push(tags[i]);
-      backtrack(i + 1, path);
-      path.pop();
-    }
-  };
-  backtrack(0, []);
-  return results;
-}
-
-function getMatchingTagGroups(
-  operators: Operator[],
-  selectedTags: string[]
-): Record<string, Operator[]> {
-  const groups: Record<string, Operator[]> = {};
-
-  const tagCombos = getCombinations(selectedTags);
-
-  tagCombos.forEach((combo) => {
-    const comboKey = combo.sort().join(" + ");
-    const matched = operators.filter((op) =>
-      combo.every((tag) => op.tags.includes(tag))
-    );
-    if (matched.length > 0) {
-      groups[comboKey] = matched;
-    }
-  });
-
-  return groups;
-}
 
 export default function OperatorList({ title, selectedTags }: Props) {
   const t = useTranslations("components.RecruitmentPage.operatorList");

--- a/src/lib/operator-utils.ts
+++ b/src/lib/operator-utils.ts
@@ -1,8 +1,8 @@
 export interface Operator {
   name: string;
   tags: string[];
-  image?: string;
-  stars?: number;
+  image: string;
+  stars: number;
 }
 
 export function getCombinations(tags: string[]): string[][] {

--- a/src/lib/operator-utils.ts
+++ b/src/lib/operator-utils.ts
@@ -1,0 +1,41 @@
+export interface Operator {
+  name: string;
+  tags: string[];
+  image?: string;
+  stars?: number;
+}
+
+export function getCombinations(tags: string[]): string[][] {
+  const results: string[][] = [];
+  const backtrack = (start: number, path: string[]) => {
+    if (path.length > 0) results.push([...path]);
+    for (let i = start; i < tags.length; i++) {
+      path.push(tags[i]);
+      backtrack(i + 1, path);
+      path.pop();
+    }
+  };
+  backtrack(0, []);
+  return results;
+}
+
+export function getMatchingTagGroups(
+  operators: Operator[],
+  selectedTags: string[]
+): Record<string, Operator[]> {
+  const groups: Record<string, Operator[]> = {};
+
+  const tagCombos = getCombinations(selectedTags);
+
+  tagCombos.forEach((combo) => {
+    const comboKey = combo.sort().join(" + ");
+    const matched = operators.filter((op) =>
+      combo.every((tag) => op.tags.includes(tag))
+    );
+    if (matched.length > 0) {
+      groups[comboKey] = matched;
+    }
+  });
+
+  return groups;
+}

--- a/tests/operatorList.test.ts
+++ b/tests/operatorList.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { getCombinations, getMatchingTagGroups, Operator } from '../src/lib/operator-utils';
+
+describe('getCombinations', () => {
+  it('returns all unique tag combinations', () => {
+    const tags = ['A', 'B', 'C'];
+    const combos = getCombinations(tags).map(c => c.sort().join(','));
+    const expected = [
+      'A',
+      'A,B',
+      'A,B,C',
+      'A,C',
+      'B',
+      'B,C',
+      'C'
+    ];
+    expect(new Set(combos)).toEqual(new Set(expected));
+  });
+});
+
+describe('getMatchingTagGroups', () => {
+  it('groups operators correctly based on selected tags', () => {
+    const operators: Operator[] = [
+      { name: 'Op1', tags: ['Guard', 'DPS'] },
+      { name: 'Op2', tags: ['Guard', 'Healing'] },
+      { name: 'Op3', tags: ['Support', 'Healing'] }
+    ];
+
+    const groups = getMatchingTagGroups(operators, ['Guard', 'Healing']);
+
+    expect(Object.keys(groups).sort()).toEqual(['Guard', 'Guard + Healing', 'Healing'].sort());
+    expect(groups['Guard'].map(o => o.name)).toEqual(['Op1', 'Op2']);
+    expect(groups['Guard + Healing'].map(o => o.name)).toEqual(['Op2']);
+    expect(groups['Healing'].map(o => o.name)).toEqual(['Op2', 'Op3']);
+  });
+});


### PR DESCRIPTION
## Summary
- add `getCombinations` and `getMatchingTagGroups` helpers in `src/lib`
- update `OperatorList` to use the new helpers
- install **vitest** and add `npm test` script
- add tests verifying combination logic and grouping logic

## Testing
- `npm install` *(fails: 403 Forbidden for vitest)*
- `npm test` *(fails: vitest not found)*


------
https://chatgpt.com/codex/tasks/task_e_683fc1e708f083229770ec0bf9404b4e