### PR TITLE
Fix UTC date display for event timeline

### DIFF
--- a/src/app/components/event/EventBar.tsx
+++ b/src/app/components/event/EventBar.tsx
@@ -38,11 +38,14 @@ export default function EventBar({ event, dateRange }: Props) {
   const endDate = parseISO(event.end);
   const isEnded = isAfter(new Date(), endDate);
 
+  const startDay = event.start.slice(0, 10);
+  const endDay = event.end.slice(0, 10);
+
   const startIndex = dateRange.findIndex(
-    (d) => d.toDateString() === startDate.toDateString()
+    (d) => d.toISOString().slice(0, 10) === startDay
   );
   const endIndex = dateRange.findIndex(
-    (d) => d.toDateString() === endDate.toDateString()
+    (d) => d.toISOString().slice(0, 10) === endDay
   );
 
   if (startIndex === -1 || endIndex === -1) return null;

--- a/src/app/components/event/EventTimeline.tsx
+++ b/src/app/components/event/EventTimeline.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { eachDayOfInterval, format, parseISO, startOfDay } from "date-fns";
+import { format } from "date-fns";
 import EventBar from "@/app/components/event/EventBar";
 import eventsDataRaw from "@/data/events.json";
 import TimeIndicator from "./TimeIndicator";
@@ -17,24 +17,30 @@ type Event = {
 
 const eventsData = eventsDataRaw as Event[];
 
+function getUtcDay(dateString: string): Date {
+  const date = new Date(dateString);
+  return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
+}
+
 export default function EventTimeline() {
   const [events, setEvents] = useState<Event[]>([]);
   const [dateRange, setDateRange] = useState<Date[]>([]);
   const t = useTranslations("components.EventPage");
 
   useEffect(() => {
-    const startDates = eventsData.map((e) => startOfDay(parseISO(e.start)));
-    const endDates = eventsData.map((e) => startOfDay(parseISO(e.end)));
+    const startDates = eventsData.map((e) => getUtcDay(e.start));
+    const endDates = eventsData.map((e) => getUtcDay(e.end));
 
     const minDate = new Date(Math.min(...startDates.map((d) => d.getTime())));
     const maxDate = new Date(Math.max(...endDates.map((d) => d.getTime())));
 
-    minDate.setDate(minDate.getDate() - 7);
-    maxDate.setDate(maxDate.getDate() + 7);
+    minDate.setUTCDate(minDate.getUTCDate() - 7);
+    maxDate.setUTCDate(maxDate.getUTCDate() + 7);
 
-    const days = eachDayOfInterval({ start: minDate, end: maxDate }).map((d) =>
-      startOfDay(new Date(d))
-    );
+    const days: Date[] = [];
+    for (let d = minDate.getTime(); d <= maxDate.getTime(); d += 86400000) {
+      days.push(new Date(d));
+    }
 
     setDateRange(days);
     setEvents(eventsData);


### PR DESCRIPTION
## Summary
- ensure EventTimeline uses UTC dates when generating the date range
- align EventBar timeline positions with UTC date strings

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fcd09dfe48322931edc52a1da8c4f